### PR TITLE
Handle missing AVFoundation in AudioManager

### DIFF
--- a/AnimalMatch/Resources/AudioManager.swift
+++ b/AnimalMatch/Resources/AudioManager.swift
@@ -1,3 +1,5 @@
+// Audio playback is available on Apple platforms via AVFoundation.
+#if canImport(AVFoundation)
 import AVFoundation
 
 /// Manages background music and sound effects.
@@ -30,3 +32,16 @@ final class AudioManager {
         effectPlayer?.play()
     }
 }
+#else
+/// Fallback audio manager used when AVFoundation is unavailable.
+/// Provides no-op implementations so the package builds on platforms
+/// that don't support audio playback.
+final class AudioManager {
+    static let shared = AudioManager()
+    private init() {}
+
+    func playBackgroundMusic() {}
+    func stopBackgroundMusic() {}
+    func playMatchSound() {}
+}
+#endif


### PR DESCRIPTION
## Summary
- guard AudioManager usage with `canImport(AVFoundation)`
- provide no-op AudioManager when AVFoundation isn't available

## Testing
- `swift build` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68b356a7f930832d87e78a5fc74c6423